### PR TITLE
Let Postgres handle default settings

### DIFF
--- a/library/Hasql/Postgres.hs
+++ b/library/Hasql/Postgres.hs
@@ -39,7 +39,7 @@ import qualified ListT
 data Postgres =
   Postgres {
     host :: ByteString,
-    port :: Word16,
+    port :: Maybe Int,
     user :: Text,
     password :: Text,
     database :: Text


### PR DESCRIPTION
Postgres provides its own defaults for missing connection string options. Rather than recreating these, users should be able to provide empty options that aren't passed into the connection string.

This also fixes the issue where providing only some blank options results in an erroneous connection bytestring.
