### PR TITLE
Composite types

### DIFF
--- a/hasql-postgres.cabal
+++ b/hasql-postgres.cabal
@@ -100,7 +100,8 @@ library
     loch-th == 0.2.*,
     placeholders == 0.1.*,
     -- general:
-    base-prelude >= 0.1.13 && < 0.2
+    base-prelude >= 0.1.13 && < 0.2,
+    base >= 4.6 && < 5
 
 
 test-suite doctest

--- a/library/Hasql/Postgres.hs
+++ b/library/Hasql/Postgres.hs
@@ -507,16 +507,16 @@ instance Bknd.CxValue Postgres J.Value where
 -- |
 -- Maps to
 -- <http://www.postgresql.org/docs/9.4/static/rowtypes.html composite types>
-newtype Composite a = Composite a
+newtype Row a = Row a
 
-instance ViaFields a => Bknd.CxValue Postgres (Composite a) where
-  encodeValue (Composite a) = StmtParam
+instance ViaFields a => Bknd.CxValue Postgres (Row a) where
+  encodeValue (Row a) = StmtParam
     (PTI.oidPQ (PTI.ptiOID PTI.record))
     (\env -> Just $ Encoder.composite (toFields env a))
 
   decodeValue (ResultValue env v) =
     case v of
-      Just fs -> Composite <$> (fromFields env =<< Decoder.composite fs)
+      Just fs -> Row <$> (fromFields env =<< Decoder.composite fs)
       Nothing -> Left "decodeValue: NULL Composite"
 
 -- | Count the number of "fields" in a data type.


### PR DESCRIPTION
Here we are again, re: #15. I had to add `base` to the cabal dependencies to be able to use `Generic`, which provides both the tuple instances for the composite type, and lets arbitrary data (so long as it's `Generic`) be used as a composite type.