### PR TITLE
Bumped aeson version.

### DIFF
--- a/hasql-postgres.cabal
+++ b/hasql-postgres.cabal
@@ -81,7 +81,7 @@ library
     postgresql-binary == 0.5.*,
     postgresql-libpq == 0.9.*,
     -- data:
-    aeson >= 0.7 && < 0.10,
+    aeson >= 0.7 && < 0.11,
     uuid == 1.3.*,
     vector == 0.10.*,
     time >= 1.4 && < 1.6,


### PR DESCRIPTION
Aeson in version 0.10 will support all possible versions of ISO 8601 UTCTimes. All tests for hasql-postgres work with aeson 0.10.