### PR TITLE
add: stack support, update deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist
+.stack-work

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.10.5.1
+* stack support
+* update dependencies
+
 # 0.10.3.1
 * "attoparsec"-0.13 support
 

--- a/hasql-postgres.cabal
+++ b/hasql-postgres.cabal
@@ -1,14 +1,14 @@
 name:
   hasql-postgres
 version:
-  0.10.5
+  0.10.5.1
 synopsis:
   A "PostgreSQL" backend for the "hasql" library
 description:
-  This library provides a \"PostgreSQL\" driver for 
+  This library provides a \"PostgreSQL\" driver for
   <http://hackage.haskell.org/package/hasql the "hasql" library>.
   .
-  It supports all Postgres versions starting from 8.3 
+  It supports all Postgres versions starting from 8.3
   and is tested against 8.3, 9.3 and 9.4
   with the @integer_datetimes@ setting off and on.
   .
@@ -20,9 +20,9 @@ description:
 category:
   Database
 homepage:
-  https://github.com/nikita-volkov/hasql-postgres 
+  https://github.com/nikita-volkov/hasql-postgres
 bug-reports:
-  https://github.com/nikita-volkov/hasql-postgres/issues 
+  https://github.com/nikita-volkov/hasql-postgres/issues
 author:
   Nikita Volkov <nikita.y.volkov@mail.ru>
 maintainer:
@@ -73,34 +73,34 @@ library
     Hasql.Postgres
   build-depends:
     -- template haskell:
-    template-haskell == 2.*,
+    template-haskell,
     -- parsers:
-    attoparsec >= 0.10 && < 0.14,
+    attoparsec >= 0.10,
     -- database:
-    hasql-backend == 0.4.*,
-    postgresql-binary == 0.5.*,
-    postgresql-libpq == 0.9.*,
+    hasql-backend,
+    postgresql-binary,
+    postgresql-libpq,
     -- data:
-    aeson >= 0.7 && < 0.10,
-    uuid == 1.3.*,
-    vector >= 0.10 && < 0.12,
-    time >= 1.4 && < 1.6,
-    hashtables >= 1.1 && < 1.3,
-    scientific >= 0.2 && < 0.4,
-    text >= 1 && < 1.3,
-    bytestring >= 0.10 && < 0.11,
-    hashable >= 1.2 && < 1.3,
+    aeson >= 0.7,
+    uuid,
+    vector >= 0.10,
+    time >= 1.4,
+    hashtables >= 1.1,
+    scientific >= 0.2,
+    text >= 1,
+    bytestring >= 0.10,
+    hashable >= 1.2,
     -- control:
-    free >= 4.6 && < 5,
-    either >= 4.3 && < 5,
-    list-t < 0.5,
-    mmorph == 1.0.*,
-    transformers >= 0.3 && < 0.5,
+    free >= 4.6,
+    either >= 4.3,
+    list-t,
+    mmorph,
+    transformers >= 0.3,
     -- errors:
-    loch-th == 0.2.*,
-    placeholders == 0.1.*,
+    loch-th,
+    placeholders,
     -- general:
-    base-prelude >= 0.1.13 && < 0.2
+    base-prelude >= 0.1.13
 
 
 test-suite doctest
@@ -113,10 +113,10 @@ test-suite doctest
   ghc-options:
     -threaded
   build-depends:
-    doctest == 0.9.*,
-    directory == 1.2.*,
-    filepath >= 1.3 && < 1.5,
-    base-prelude == 0.1.*,
+    doctest,
+    directory,
+    filepath >= 1.3,
+    base-prelude,
     base
   default-extensions:
     Arrows, BangPatterns, ConstraintKinds, DataKinds, DefaultSignatures, DeriveDataTypeable, DeriveFunctor, DeriveGeneric, EmptyDataDecls, FlexibleContexts, FlexibleInstances, FunctionalDependencies, GADTs, GeneralizedNewtypeDeriving, ImpredicativeTypes, LambdaCase, LiberalTypeSynonyms, MultiParamTypeClasses, MultiWayIf, NoImplicitPrelude, NoMonomorphismRestriction, OverloadedStrings, PatternGuards, ParallelListComp, QuasiQuotes, RankNTypes, RecordWildCards, ScopedTypeVariables, StandaloneDeriving, TemplateHaskell, TupleSections, TypeFamilies, TypeOperators
@@ -144,29 +144,29 @@ test-suite hspec
     postgresql-binary,
     hasql-postgres,
     hasql-backend,
-    hasql == 0.7.*,
+    hasql,
     -- testing:
-    hspec == 2.1.*,
-    quickcheck-instances == 0.3.*,
-    QuickCheck == 2.7.*,
+    hspec,
+    quickcheck-instances,
+    QuickCheck,
     -- data:
     aeson,
     vector,
-    old-locale == 1.0.*,
-    time >= 1.4 && < 1.6,
-    scientific >= 0.2 && < 0.4,
-    text >= 1 && < 1.3,
-    bytestring >= 0.10 && < 0.11,
-    hashable >= 1.2 && < 1.3,
+    old-locale,
+    time >= 1.4,
+    scientific >= 0.2,
+    text >= 1,
+    bytestring >= 0.10,
+    hashable >= 1.2,
     -- general:
     either,
-    list-t < 0.5,
-    mtl-prelude < 3,
-    base-prelude >= 0.1.3 && < 0.2
+    list-t,
+    mtl-prelude,
+    base-prelude >= 0.1.3
 
 
 benchmark competition
-  type: 
+  type:
     exitcode-stdio-1.0
   hs-source-dirs:
     competition
@@ -182,27 +182,26 @@ benchmark competition
   default-language:
     Haskell2010
   build-depends:
-    HDBC == 2.4.*,
-    HDBC-postgresql == 2.3.*,
-    postgresql-simple == 0.4.*,
+    HDBC,
+    HDBC-postgresql,
+    postgresql-simple,
     hasql-postgres,
     hasql-backend,
-    hasql == 0.7.*,
+    hasql,
     -- random:
-    QuickCheck == 2.7.*,
-    quickcheck-instances == 0.3.*,
+    QuickCheck,
+    quickcheck-instances,
     -- benchmarking:
-    criterion-plus == 0.1.*,
+    criterion-plus,
     -- data:
     vector,
-    time >= 1.4 && < 1.6,
-    text >= 1 && < 1.3,
-    scientific >= 0.2 && < 0.4,
+    time >= 1.4,
+    text >= 1,
+    scientific >= 0.2,
     -- general:
     either,
-    monad-control >= 0.3 && < 1.1,
-    deepseq == 1.*,
-    list-t < 0.5,
-    mtl-prelude < 3,
-    base-prelude >= 0.1.3 && < 0.2
-
+    monad-control >= 0.3,
+    deepseq,
+    list-t,
+    mtl-prelude,
+    base-prelude >= 0.1.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,8 @@
+flags: {}
+packages:
+- '.'
+extra-deps:
+  - criterion-plus-0.1.3
+  - HDBC-2.4.0.1
+  - HDBC-postgresql-2.3.2.3
+resolver: lts-3.5


### PR DESCRIPTION
- Removes upper bounds on dependencies
- Adds stack support, defaulting to GHC-7.10
- Tested with: GHC-7.8.4, GHC-7.10.2
- Tested against updated: hasql-backend, hasql
- .gitignore for dist, .stack-work

Here's everything working together:

```
allele@parametric:~/dev/hasql:$ stack clean
allele@parametric:~/dev/hasql:$ ls
hasql  hasql-backend  hasql-postgres  stack.yaml
allele@parametric:~/dev/hasql:$ more stack.yaml 
```

``` yaml
flags: {}
packages:
- hasql/
- hasql-backend/
- hasql-postgres/
extra-deps:
  - criterion-plus-0.1.3
  - HDBC-2.4.0.1
  - HDBC-postgresql-2.3.2.3
resolver: lts-3.5
```

```
allele@parametric:~/dev/hasql:$ stack build
hasql-0.7.4.1-20792b88031018a947c17120d8d34883: unregistering (missing dependencies: hasql-backend)
hasql-backend-0.4.2.1-9959897ad3289b5d63d117ec27d34e52: unregistering (local file changes)
hasql-postgres-0.10.5.1-18a2f341b426f90a2f04dca5868cd235: unregistering (missing dependencies: hasql-backend)
hasql-backend-0.4.2.1: configure
hasql-backend-0.4.2.1: build
hasql-backend-0.4.2.1: install
hasql-0.7.4.1: configure
hasql-0.7.4.1: build
hasql-postgres-0.10.5.1: configure
hasql-postgres-0.10.5.1: build
hasql-0.7.4.1: install
hasql-postgres-0.10.5.1: install
Completed all 3 actions.
```
